### PR TITLE
Bugfix: incorrect name for gradients

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+2024.5.23.2 -- Bugfix: incorrect name for gradients
+   * There was a typo in the name for the gradients, such that they could not be output
+     to Results.json.
+   * The units for the energy and gradients in Results.json were incorrect.
+     
 2024.5.23.1 -- Internal fix for creating Docker image.
 
 2024.5.23 -- Added standard energy and gradients to results

--- a/psi4_step/accelerated_optimization.py
+++ b/psi4_step/accelerated_optimization.py
@@ -11,7 +11,8 @@ import textwrap
 import traceback
 
 import numpy as np
-import optking
+
+# import optking
 from scipy.optimize import minimize, OptimizeResult
 from scipy.optimize._optimize import (
     _prepare_scalar_function,
@@ -263,7 +264,7 @@ class AcceleratedOptimization(psi4_step.Energy):
                     printer.normal("NOT Converged!!!!!!")
         else:
             # Iterate
-            molecule = configuration.to_qcschema_dict()
+            # molecule = configuration.to_qcschema_dict()
             optking_options = {
                 "step_type": P["optimization method"],
                 "g_convergence": P["geometry convergence"],
@@ -283,7 +284,8 @@ class AcceleratedOptimization(psi4_step.Energy):
             # "rms_force_g_convergence": 3.0e-04,
             # "intrafrag_hess": "SIMPLE",
 
-            optimizer = optking.CustomHelper(molecule, optking_options)
+            # optimizer = optking.CustomHelper(molecule, optking_options)
+            optimizer = None
 
             # The initial coordinates as NUMPY array. Psi4 may reorient, so need
             # to run and cache the first results
@@ -377,18 +379,19 @@ class AcceleratedOptimization(psi4_step.Energy):
         # Handle the system
         _, configuration = self.get_system_configuration()
 
-        molecule = configuration.to_qcschema_dict()
-        # "g_convergence": "gau",
-        optking_options = {
-            "opt_coordinates": "cartesian",
-            "g_convergence": "cfour",
-            "max_force_g_convergence": 4.5e-04,
-            "rms_force_g_convergence": 3.0e-04,
-            "FULL_HESS_EVERY": 1,
-            "intrafrag_hess": "SIMPLE",
-        }
+        # molecule = configuration.to_qcschema_dict()
+        # # "g_convergence": "gau",
+        # optking_options = {
+        #     "opt_coordinates": "cartesian",
+        #     "g_convergence": "cfour",
+        #     "max_force_g_convergence": 4.5e-04,
+        #     "rms_force_g_convergence": 3.0e-04,
+        #     "FULL_HESS_EVERY": 1,
+        #     "intrafrag_hess": "SIMPLE",
+        # }
         # "hess_update": "none",
-        optimizer = optking.CustomHelper(molecule, optking_options)
+        # optimizer = optking.CustomHelper(molecule, optking_options)
+        optimizer = None
 
         # First calculate the derivatives with both Psi4 and MOPAC
         xyz0 = np.array(optimizer.geom).flatten()

--- a/psi4_step/energy.py
+++ b/psi4_step/energy.py
@@ -336,9 +336,11 @@ for item in arrays:
 variables["Eelec"] = Eelec
 variables["energy"] = Eelec
 try:
-    variables["gradient"] = np.array(G).tolist()
-except Exception:
-    pass
+    variables["gradients"] = np.array(G).tolist()
+except Exception as e:
+    print("Problem with gradients!")
+    print(e)
+
 variables["_method"] = "{method}"
 variables["_method_string"] = "{method_string}"
 

--- a/psi4_step/psi4_metadata.py
+++ b/psi4_step/psi4_metadata.py
@@ -1629,13 +1629,13 @@ metadata["results"] = {
         "dimensionality": "scalar",
         "property": "total energy#Psi4#{model}",
         "type": "float",
-        "units": "kJ/mol",
+        "units": "E_h",
     },
     "gradients": {
         "description": "The gradients",
         "dimensionality": "[3, n_atoms]",
         "type": "float",
-        "units": "kJ/mol/Å",
+        "units": "E_h/a_0",
     },
     "(T) CORRECTION ENERGY": {
         "calculation": ["energy", "optimization", "thermochemistry", "vibrations"],


### PR DESCRIPTION
   * There was a typo in the name for the gradients, such that they could not be output to Results.json.
   * The units for the energy and gradients in Results.json were incorrect.