### PR TITLE
Added auxialliary codes that help Psi4

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2024.5.23.3 -- Added auxialliary codes that help Psi4
+   * Psi4 uses codes like DFTD4 and DFTD4 for parts of e.g. dispersion
+     calculations. This release adds them to the Conda install SEAMM uses for Psi4.
+     
 2024.5.23.2 -- Bugfix: incorrect name for gradients
    * There was a typo in the name for the gradients, such that they could not be output
      to Results.json.

--- a/psi4_step/data/seamm-psi4.yml
+++ b/psi4_step/data/seamm-psi4.yml
@@ -1,10 +1,16 @@
 name: seamm-psi4
 channels:
   - conda-forge
-  - conda-forge/label/libint_dev
 dependencies:
   - python
 
-    # Executables, etc.
-  - geometric
   - psi4
+
+  # Optional packages
+  - basis_set_exchange
+  - dftd3-python>=1.0
+  - dftd4-python
+  - gcp-correction
+  - geometric
+  - pymdi
+  - toml # req'd with dftd4-python


### PR DESCRIPTION
* Psi4 uses codes like DFTD4 and DFTD4 for parts of e.g. dispersion calculations. This release adds them to the Conda install SEAMM uses for Psi4.