### PR TITLE
Bugfix: catch a mis-assigned per-fragment BSSE charge before running Psi4

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,14 @@ History
      complex's own charge and pass validation, only to fail deep inside Psi4
      once that fragment ran as an impossible odd-electron singlet. This is now
      caught up front with a clear message naming the offending fragment.
+   * Leaving ``fragment charges`` empty no longer always means all-neutral: if
+     the structure carries per-atom formal charges (e.g. an ion marked with an
+     SDF/MOL ``M  CHG`` record, such as the Na+ in a ``Na+..H2O`` complex), each
+     fragment now defaults to the sum of its own atoms' formal charge. This
+     covers monatomic ions (Na+, Cl-) and polyatomic ions (NH4+, BF4-) alike
+     without the caller needing to spell out ``fragment charges`` at all --
+     removing the main way to trigger the mis-assignment above in the first
+     place. An explicit ``fragment charges`` still overrides it.
 
 2026.8.4 -- Added a BSSE (counterpoise) sub-step
    * New BSSE sub-step: computes the counterpoise-corrected (Boys-Bernardi)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,16 @@
 =======
 History
 =======
+2026.8.7 -- Bugfix: catch a mis-assigned per-fragment BSSE charge before running Psi4
+   * The BSSE (counterpoise) sub-step now passes the cluster's atomic numbers into
+     ``seamm_bsse.validate_fragments``, which checks that every fragment has an
+     even electron count at its assigned charge. Previously, a per-fragment
+     charge given to the wrong fragment (e.g. an ion's charge assigned to its
+     neutral partner instead of the ion) could still sum correctly to the
+     complex's own charge and pass validation, only to fail deep inside Psi4
+     once that fragment ran as an impossible odd-electron singlet. This is now
+     caught up front with a clear message naming the offending fragment.
+
 2026.8.4 -- Added a BSSE (counterpoise) sub-step
    * New BSSE sub-step: computes the counterpoise-corrected (Boys-Bernardi)
      energy and gradient of an N-fragment complex, with an independent charge

--- a/psi4_step/bsse.py
+++ b/psi4_step/bsse.py
@@ -97,8 +97,12 @@ class BSSE(psi4_step.Energy):
     def _fragments(self, P, configuration):
         """Return the N ``seamm_bsse.Fragment`` for this complex, per the
         'fragments' parameter, with per-fragment charge threaded in from
-        'fragment charges'. Validates against the complex's own
-        charge/multiplicity before returning."""
+        'fragment charges' -- or, if that is left empty, from the sum of each
+        fragment's atoms' ``formal_charge`` (set on ``configuration.atoms``
+        when the structure came from a format that carries per-atom formal
+        charges, e.g. an SDF/MOL file's ``M  CHG`` record), falling back to
+        all-neutral if neither is available. Validates against the complex's
+        own charge/multiplicity before returning."""
         n_atoms = configuration.n_atoms
         mode = P["fragments"]
         if mode == "specified":
@@ -117,7 +121,18 @@ class BSSE(psi4_step.Energy):
 
         charges = self._parse_charges(P["fragment charges"])
         if not charges:
-            charges = [0] * len(groups)
+            if "formal_charge" in configuration.atoms:
+                formal_charges = configuration.atoms["formal_charge"]
+                charges = [sum(formal_charges[i] for i in group) for group in groups]
+                printer.important(
+                    __(
+                        "No 'fragment charges' given; using each fragment's "
+                        "net formal charge from the input structure.",
+                        indent=self.indent + 4 * " ",
+                    )
+                )
+            else:
+                charges = [0] * len(groups)
         elif len(charges) != len(groups):
             raise RuntimeError(
                 f"BSSE: {len(charges)} 'fragment charges' given but "

--- a/psi4_step/bsse.py
+++ b/psi4_step/bsse.py
@@ -135,6 +135,7 @@ class BSSE(psi4_step.Energy):
                 fragments,
                 cluster_charge=configuration.charge,
                 cluster_multiplicity=configuration.spin_multiplicity,
+                atomic_numbers=configuration.atoms.atomic_numbers,
             )
         except ValueError as e:
             raise RuntimeError(f"BSSE: {e}") from e

--- a/psi4_step/bsse_parameters.py
+++ b/psi4_step/bsse_parameters.py
@@ -62,10 +62,13 @@ class BSSEParameters(EnergyParameters):
                 "fragments (the order 'auto' finds molecules, or the "
                 "semicolon-separated groups in 'Fragment atoms') -- a "
                 "comma/space separated list of integers, e.g. '1, -1' for a "
-                "Na+/Cl- pair. Leave empty for all-neutral fragments (the usual "
-                "case for a neutral H-bonded complex). Every fragment is "
-                "closed-shell (multiplicity 1); the complex's own charge and "
-                "multiplicity are checked against these for consistency."
+                "Na+/Cl- pair. Leave empty to use each fragment's net formal "
+                "charge from the input structure, if the structure format "
+                "carries one (e.g. an ion marked with an SDF/MOL 'M  CHG' "
+                "record) -- otherwise all-neutral (the usual case for a "
+                "neutral H-bonded complex). Every fragment is closed-shell "
+                "(multiplicity 1); the complex's own charge and multiplicity "
+                "are checked against these for consistency."
             ),
         },
         "compute gradient": {

--- a/tests/test_bsse.py
+++ b/tests/test_bsse.py
@@ -101,13 +101,68 @@ def test_bsse_fragments_auto_needs_at_least_two_molecules():
 
 
 class _FakeAtoms:
-    def __init__(self, symbols, coords, atomic_numbers=None):
+    """A minimal stand-in for `configuration.atoms` -- symbols/get_coordinates
+    for `_molecule_block`, `atomic_numbers` for the BSSE electron-parity
+    check, and `formal_charge` (`in`/`[]`, like the real molsystem atoms
+    table) for the 'fragment charges' structure-derived default."""
+
+    def __init__(
+        self, symbols=None, coords=None, atomic_numbers=None, formal_charge=None
+    ):
         self.symbols = symbols
         self._coords = coords
         self.atomic_numbers = atomic_numbers
+        self._formal_charge = formal_charge
 
     def get_coordinates(self, fractionals=False, in_cell=True):
         return self._coords
+
+    def __contains__(self, key):
+        return key == "formal_charge" and self._formal_charge is not None
+
+    def __getitem__(self, key):
+        if key == "formal_charge" and self._formal_charge is not None:
+            return self._formal_charge
+        raise KeyError(key)
+
+
+def test_bsse_fragments_default_charges_from_formal_charge():
+    """No 'fragment charges' given, but the structure (e.g. read from an SDF
+    with an 'M  CHG' record) carries per-atom formal charges -- the Na+..H2O
+    pilot case: water (O, H, H) neutral, Na+ +1. Each fragment's default
+    charge must be the sum of its own atoms' formal_charge, not 0."""
+    node = psi4_step.BSSE()
+    node._id = ("1",)
+    configuration = SimpleNamespace(
+        n_atoms=4,
+        charge=1,
+        spin_multiplicity=1,
+        find_molecules=lambda as_indices=True: [[0, 1, 2], [3]],
+        atoms=_FakeAtoms(atomic_numbers=[8, 1, 1, 11], formal_charge=[0, 0, 0, 1]),
+    )
+    P = {"fragments": "auto (molecules)", "fragment atoms": "", "fragment charges": ""}
+    fragments = node._fragments(P, configuration)
+    assert [f.atom_indices for f in fragments] == [(0, 1, 2), (3,)]
+    assert [f.charge for f in fragments] == [0, 1]
+
+
+def test_bsse_fragments_explicit_charges_override_formal_charge():
+    """An explicit 'fragment charges' still wins over the structure's own
+    (here, deliberately wrong/absent-looking) formal charges."""
+    node = psi4_step.BSSE()
+    configuration = SimpleNamespace(
+        n_atoms=2,
+        charge=0,
+        spin_multiplicity=1,
+        atoms=_FakeAtoms(atomic_numbers=[11, 17], formal_charge=[0, 0]),
+    )
+    P = {
+        "fragments": "specified",
+        "fragment atoms": "1; 2",
+        "fragment charges": "1, -1",
+    }
+    fragments = node._fragments(P, configuration)
+    assert [f.charge for f in fragments] == [1, -1]
 
 
 def test_bsse_molecule_block_two_fragments():

--- a/tests/test_bsse.py
+++ b/tests/test_bsse.py
@@ -54,7 +54,12 @@ def test_bsse_fragments_specified_charged_na_cl():
     """The Na+/Cl- pilot case: 'specified' fragments, per-fragment charge,
     neutral overall complex."""
     node = psi4_step.BSSE()
-    configuration = SimpleNamespace(n_atoms=2, charge=0, spin_multiplicity=1)
+    configuration = SimpleNamespace(
+        n_atoms=2,
+        charge=0,
+        spin_multiplicity=1,
+        atoms=SimpleNamespace(atomic_numbers=[11, 17]),
+    )
     P = {
         "fragments": "specified",
         "fragment atoms": "1; 2",
@@ -67,7 +72,12 @@ def test_bsse_fragments_specified_charged_na_cl():
 
 def test_bsse_fragments_charge_mismatch_raises():
     node = psi4_step.BSSE()
-    configuration = SimpleNamespace(n_atoms=2, charge=0, spin_multiplicity=1)
+    configuration = SimpleNamespace(
+        n_atoms=2,
+        charge=0,
+        spin_multiplicity=1,
+        atoms=SimpleNamespace(atomic_numbers=[11, 17]),
+    )
     P = {
         "fragments": "specified",
         "fragment atoms": "1; 2",
@@ -91,9 +101,10 @@ def test_bsse_fragments_auto_needs_at_least_two_molecules():
 
 
 class _FakeAtoms:
-    def __init__(self, symbols, coords):
+    def __init__(self, symbols, coords, atomic_numbers=None):
         self.symbols = symbols
         self._coords = coords
+        self.atomic_numbers = atomic_numbers
 
     def get_coordinates(self, fractionals=False, in_cell=True):
         return self._coords
@@ -109,6 +120,7 @@ def test_bsse_molecule_block_two_fragments():
         atoms=_FakeAtoms(
             ["Na", "Cl"],
             [(0.0, 0.0, 0.0), (0.0, 0.0, 2.44)],
+            atomic_numbers=[11, 17],
         )
     )
     fragments = node._fragments(
@@ -117,7 +129,12 @@ def test_bsse_molecule_block_two_fragments():
             "fragment atoms": "1; 2",
             "fragment charges": "1, -1",
         },
-        SimpleNamespace(n_atoms=2, charge=0, spin_multiplicity=1),
+        SimpleNamespace(
+            n_atoms=2,
+            charge=0,
+            spin_multiplicity=1,
+            atoms=SimpleNamespace(atomic_numbers=[11, 17]),
+        ),
     )
     block = node._molecule_block(fragments, configuration, name="bsse_cluster")
     lines = block.splitlines()


### PR DESCRIPTION
* The BSSE (counterpoise) sub-step now passes the cluster's atomic numbers into
  `seamm_bsse.validate_fragments`, which checks that every fragment has an even
  electron count at its assigned charge. Previously, a per-fragment charge given
  to the wrong fragment (e.g. an ion's charge assigned to its neutral partner
  instead of the ion) could still sum correctly to the complex's own charge and
  pass validation, only to fail deep inside Psi4 once that fragment ran as an
  impossible odd-electron singlet. This is now caught up front with a clear
  message naming the offending fragment.
* Leaving `fragment charges` empty no longer always means all-neutral: if the
  structure carries per-atom formal charges (e.g. an ion marked with an SDF/MOL
  `M  CHG` record, such as the Na+ in a `Na+..H2O` complex), each fragment now
  defaults to the sum of its own atoms' formal charge. This covers monatomic
  ions (Na+, Cl-) and polyatomic ions (NH4+, BF4-) alike without the caller
  needing to spell out `fragment charges` at all -- removing the main way to
  trigger the mis-assignment above in the first place. An explicit
  `fragment charges` still overrides it.

Depends on molssi-seamm/seamm_bsse#8.